### PR TITLE
Update incorrect link for SUSE package HUB

### DIFF
--- a/proposed.md
+++ b/proposed.md
@@ -16,7 +16,7 @@ You can reach out to the mentor(s) mentioned, or the overall project owner, if y
   * [Build components of a containerized implementation of Cloud Foundry on Z](/proposed_projects/Build%20components%20of%20a%20containerized%20implementation%20of%20Cloud%20Foundry%20on%20Z.md)
   * [Compliance engine](/proposed_projects/Compliance%20engine.md)
   * [Document the deployment of Kubernetes cluster on IBM LinuxONE](proposed_projects/Document%20the%20deployment%20of%20Kubernetes%20cluster%20on%20IBM%20LinuxONE.md)
-  * [Increase the number of s390x packages in SUSE Package Hub](proposed_projects/Close%20the%20gap%20of%20s390x%20packages%20in%20SUSE%20Package%20Hub.md)
+  * [Increase the number of s390x packages in SUSE Package Hub](proposed_projects/Increase%20the%20number%20of%20s390x%20packages%20in%20SUSE%20Package%20Hub.md)
   * [Legacy Projects](/proposed_projects/Legacy.md)
   * [VMLINK Automounter](/proposed_projects/VMLINK.md)
   * [Alpine Linux on z/VM and LPAR](/proposed_projects/Alpine.md)


### PR DESCRIPTION
The link to project was giving 404. Made changes to direct it to the right page.